### PR TITLE
Update 02_proxy.ini

### DIFF
--- a/etc/supervisor.d/02_proxy.ini
+++ b/etc/supervisor.d/02_proxy.ini
@@ -2,3 +2,4 @@
 command=sockd -N 2 -D
 autorestart=true
 priority=20
+startretries=15


### PR DESCRIPTION
Dante / sockd attempts to start before tun0 is up and will reach the default retry limit of 3, resulting in a FATAL state. This update allows it to continuously retry up to 15 times until tun0 is established.