### PR TITLE
v0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+VPN/*
 *.ovpn
 auth.txt
 proxychains.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:latest
 
 # Install packages
 RUN apk --no-cache add openvpn dante-server supervisor && \

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ botnet on the cheap.
 - `proxychains4` is required for interactive mode
 
 ## Setup
-- Create an `auth.txt` file with your ovpn credentials in `VPN`. The format is:
+- Create an `NAME.txt` file with your ovpn credentials in `VPN`. The format is:
   ```txt
   username
   password
   ```
 - Fill the VPN folder with `*.ovpn` files and ensure that the `auth-user-pass`
-  directive in your `./VPN/*.ovpn` files says `auth-user-pass auth.txt`
+  directive in your `./VPN/*.ovpn` files says `auth-user-pass NAME.txt`
    - Check out [this wiki section](../../wiki#getting-started-with-vpn-providers)
      for installation instructions for individual VPN providers
 - Within the VPN folder, you may divide/organize your VPN file into subdirectories
@@ -47,10 +47,22 @@ botnet on the cheap.
      those configs
 
      ```sh
-     mkdir -p VPN/HMA/US
-     mv *.opvn auth.txt VPN/HMA/US
-     doxycannon vpn --dir VPN/HMA/US --single
+     mkdir -p VPN/US
+     mv US.opvn auth-us.txt VPN/US
+     doxycannon vpn --dir VPN/US --up
+
+     mkdir -p VPN/FR
+     mv FR.opvn auth-fr.txt VPN/FR
+     doxycannon vpn --dir VPN/FR --up
      ```
+
+- If `--dir` is equal to `VPN`, a container will be launched for each `ovpn` file inside the folder. Use `--single` to have HAproxy load-balance between all VPNs.
+    ```sh
+     doxycannon vpn --dir VPN --up
+     doxycannon vpn --dir VPN --single # Launch HAproxy to load balance
+     ```
+
+- `--single` does not stop proxy containers when it quits, it only stops HAproxy. Use `--down` to bring them down.
 
 - Alternatively, use the `tor` subcommand to just spin up tor nodes
 

--- a/doxycannon.py
+++ b/doxycannon.py
@@ -1,24 +1,29 @@
 #!/usr/bin/env python3
 
+import argparse
+import os
+import platform
+import re
 import signal
 import sys
-import argparse
+
 from pathlib import Path
-import os
-import sys
-import re
 from threading import Thread
 from queue import Queue
 
 import docker
 
-VERSION = '0.4.5'
+VERSION = '0.5.0'
 IMAGE = 'audibleblink/doxycannon'
 TOR = 'audibleblink/tor'
 DOXY = 'audibleblink/doxyproxy'
-THREADS = 20
+
+THREADS = 10
 START_PORT = 9000
 HAPORT = 1337
+
+platform = platform.uname()[3].lower()
+IS_DOCKER_VM = "microsoft" in platform or "darwin" in platform 
 
 PROXYCHAINS_CONF = './proxychains.conf'
 PROXYCHAINS_TEMPLATE = """
@@ -100,7 +105,11 @@ def write_config(filename, data, conf_type):
 def write_haproxy_conf(port_range):
     """Generates HAProxy config based on # of ovpn files"""
     print("[+] Writing HAProxy configuration")
-    conf_line = "\tserver doxy{} 127.0.0.1:{} check"
+    if IS_DOCKER_VM:
+        # https://github.com/docker/for-win/issues/6736#issuecomment-630044405
+        conf_line = "\tserver doxy{} host.docker.internal:{} check"
+    else:
+        conf_line = "\tserver doxy{} 127.0.0.1:{} check"
     data = list(map(lambda x: conf_line.format(x, x), port_range))
     write_config(HAPROXY_CONF, data, 'haproxy')
 
@@ -243,32 +252,36 @@ def up(image, conf):
     start_containers(image, ovpn_file_queue, port_range)
 
 
-def tor(image, count):
+def tor(count):
     """Start <count> tor nodes to proxy through
 
     Will take the given number of tor nodes and start a proxy
     rotator that cycles through the tor nodes
     """
-    if not doxy.images.list(name=image):
-        build(image, path='./tor/')
+    if not doxy.images.list(name=TOR):
+        build(TOR, path='./tor/')
 
     port_range = range(START_PORT, START_PORT + count)
     name_queue = Queue(maxsize=0)
     for port in port_range:
         name_queue.put("tor_{}".format(port))
-    start_containers(image, name_queue, port_range)
+    start_containers(TOR, name_queue, port_range)
 
 
-def rotate(image, port_range):
+def rotate(port_range):
     """Creates a proxy rotator, HAProxy, based on the port range provided"""
     try:
         write_haproxy_conf(port_range)
-        if not doxy.images.list(name=image):
-            build(image, path='./haproxy')
+        build(DOXY, path='./haproxy')
         print('[*] Staring single-port mode...')
-        print('[*] Proxy rotator listening on port 1337. Ctrl-c to quit')
+        print(f"[*] Proxy rotator listening on port {HAPORT}. Ctrl-c to quit")
         signal.signal(signal.SIGINT, signal_handler)
-        doxy.containers.run(DOXY, network='host', name=DOXY, auto_remove=True)
+        cname = DOXY.split("/")[1]
+        if IS_DOCKER_VM:
+            ports = {f"{HAPORT}/tcp": HAPORT}
+            doxy.containers.run(DOXY, name=cname, auto_remove=True, ports=ports)
+        else:
+            doxy.containers.run(DOXY, name=cname, auto_remove=True, network='host')
     except Exception as err:
         print(err)
         raise
@@ -278,7 +291,7 @@ def single(image, conf):
     """Starts an HAProxy rotator.
 
     Builds and starts the HAProxy container in the haproxy folder
-    This will create a local socks5 proxy on port 1337 that will
+    This will create a local socks5 proxy on port $HAPORT that will
     allow one to configure applications with SOCKS proxy options.
     Ex: Firefox, BurpSuite, etc.
     """
@@ -288,7 +301,7 @@ def single(image, conf):
 
     ovpn_file_count = len(list(vpn_file_queue(conf).queue))
     port_range = range(START_PORT, START_PORT + ovpn_file_count)
-    rotate(DOXY, port_range)
+    rotate(port_range)
 
 
 def interactive(image, conf):
@@ -321,6 +334,7 @@ def signal_handler(*args):
     print('\n[*] {} was issued a stop command'.format(DOXY))
     print('[*] Your proxies are still running.')
     sys.exit(0)
+
 
 def get_parsed():
     parser = argparse.ArgumentParser()
@@ -424,15 +438,16 @@ def get_parsed():
 
     return parser.parse_args()
 
+
 def handle_tor(args):
     if args.clean:
         clean(TOR)
     elif args.up:
-        tor(TOR, args.nodes)
+        tor(args.nodes)
     elif args.down:
         down(TOR)
     elif args.single:
-        rotate(DOXY, range(START_PORT, START_PORT+args.nodes))
+        rotate(range(START_PORT, START_PORT + args.nodes))
 
 
 def handle_vpn(args):
@@ -466,9 +481,9 @@ def main(args):
 
 
 if __name__ == "__main__":
-    try: 
+    try:
         doxy = docker.from_env()
-    except Exception as err:
+    except Exception:
         print("Unable to contact local Docker daemon. Is it running?")
         sys.exit(1)
     args = get_parsed()

--- a/etc/supervisor.d/01_openvpn.ini
+++ b/etc/supervisor.d/01_openvpn.ini
@@ -1,4 +1,4 @@
 [program:openvpn]
-command=/usr/sbin/openvpn --cd /VPN --config %(ENV_VPN)s.ovpn
+command=/usr/sbin/openvpn --cd %(ENV_VPNPATH)s --config %(ENV_VPN)s.ovpn
 autorestart=true
 priority=10

--- a/etc/supervisor.d/02_proxy.ini
+++ b/etc/supervisor.d/02_proxy.ini
@@ -1,5 +1,5 @@
 [program:dante]
-command=sockd -N 2 -D
+command=sockd -N 2
 autorestart=true
 priority=20
 startretries=15


### PR DESCRIPTION
Incorporates a squased #29 from @oXis. Thanks!

Bugs
 * fixes supervisor dangling processes (thanks @oXis)
 * doxyproxy container name cant have slashes
 * wrong port displayed on doxyproxy start message when using configured
   port

Enhancements
  * Configurable port for doxyproxy (thanks @oXis)
  * Configurable VPN folder selection (thanks @oXis)
  * Now works without `privileged=true`
  * Added support for WSL2
  * Docker daemons that run in VMs (windows/macos): use special hostname
    for haproxy that points to the VM IP running the daemon.
    `network=host` doesn't work on those environments
  * Fewer default threads
